### PR TITLE
Add a new recent stories tab.

### DIFF
--- a/app/coho-20-view.js
+++ b/app/coho-20-view.js
@@ -102,6 +102,7 @@ pushPanelStackByUUID: function(uuid)
         if (storyData.uuid == Coho.currentTab.stack[0].uuid) {
             Coho.currentTab.stack[0].storyData = storyData;
         }
+        Coho.Story.addRecent(uuid);
     });
 
     Coho.View.pushPanelStack(selectedStoryPanel);
@@ -122,8 +123,9 @@ pushPanelStackItemtap: function(list, index, item, e)
     selectedStoryPanel.uuid = rec.get("uuid");
     Coho.currentTab.stack.unshift({type:"story", uuid:rec.get("uuid"), back:"Back", storyData:rec.data});
 
-    Coho.View.hideTabBar();
+    Coho.Story.addRecent(selectedStoryPanel.uuid);
 
+    Coho.View.hideTabBar();
     Coho.View.pushPanelStack(selectedStoryPanel);
 },
 

--- a/app/ext-90-tab-recent.js
+++ b/app/ext-90-tab-recent.js
@@ -1,0 +1,37 @@
+/**
+ * The recently read stories tab.
+ *
+ * Inherits from the magical Coho.StoryListObject.
+ *
+ */
+Coho.tabs.recent = new Coho.StoryListObject({
+	store: new Ext.data.Store({
+        model: "story",
+        data: Coho.Story.getRecent(),
+        autoLoad: true
+    }),
+
+    groupedList: false,
+
+    storyRootLabel: "Recent",
+    saveToSessionOnRender: true,
+
+    titleBar: {
+        xtype: "toolbar",
+        dock: "top",
+        id: "recentTitleBar"
+    },
+
+    panelTitle: "Recent",
+    panelIcon: "inbox2"
+
+});
+
+Coho.tabs.recent.refresh = function()
+{
+    Coho.tabs.recent.store.loadData(Coho.Story.getRecent());
+    Coho.tabs.recent.list.refresh();
+};
+
+Coho.tabs.recent.stack.unshift({type:"root", uuid:"recent", back:"Recent"});
+

--- a/app/ext-95-startup.js
+++ b/app/ext-95-startup.js
@@ -5,6 +5,7 @@
  */
 var mainTabPanels = [
     Coho.tabs.latestStoriesTab.panel,
+    Coho.tabs.recent.panel,
     Coho.tabs.topicsTab.panel,
     Coho.tabs.searchTab.panel,
     Coho.tabs.savedStoriesTab.panel,


### PR DESCRIPTION
One of the things that has always bothered me about the Tyee app is that there is no way to go back to recently read stories.  This pull request includes some code that implements the feature.

I did not add a new icon for two reasons:
1. I'm not a graphic designer and wouldn't be able to make a good one.
2. I don't understand how the icons are loaded and where they are stored.

So, I re-used the icon for the latest tab.

I'd be happy to make any changes you request.  Thanks.
